### PR TITLE
Solving for Ryzen TSC Issue

### DIFF
--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -23,7 +23,7 @@
 #endif
 
 #include <thread>
-
+#include <fstream>
 #include "util/asm.hpp"
 #include "util/fence.hpp"
 
@@ -822,6 +822,50 @@ static const bool s_tsc_freq_evaluated = []() -> bool
 
 		const ullong timer_freq = freq.QuadPart;
 #else
+
+#ifdef __linux__
+		// Check if system clocksource is TSC. If the kernel trusts the TSC, we should too.
+		// Some Ryzen laptops have broken firmware when running linux (requires a kernel patch). This is also a problem on some older intel CPUs.
+		const char* clocksource_file = "/sys/devices/system/clocksource/clocksource0/available_clocksource";
+		if (!fs::is_file(clocksource_file))
+		{
+			// OS doesn't support sysfs?
+			printf("[TSC calibration] Could not determine available clock sources. Disabling TSC.\n");
+			return 0;
+		}
+
+		std::string clock_sources;
+		std::ifstream file(clocksource_file);
+		std::getline(file, clock_sources);
+
+		if (file.fail())
+		{
+			printf("[TSC calibration] Could not read the available clock sources on this system. Disabling TSC.\n");
+			return 0;
+		}
+
+		printf("[TSC calibration] Available clock sources: '%s'\n", clock_sources.c_str());
+
+		// Check if the Kernel has blacklisted the TSC
+		const auto available_clocks = fmt::split(clock_sources, { " " });
+		const bool tsc_reliable = std::find(available_clocks.begin(), available_clocks.end(), "tsc") != available_clocks.end();
+
+		if (!tsc_reliable)
+		{
+			printf("[TSC calibration] TSC is not a supported clock source on this system.\n");
+			return 0;
+		}
+
+		printf("[TSC calibration] Kernel reports the TSC is reliable.\n");
+#else
+		if (utils::get_cpu_brand().find("Ryzen") != umax)
+		{
+			// MacOS is arm-native these days and I don't know much about BSD to fix this if it's an issue. (kd-11)
+			// Having this check only for Ryzen is broken behavior - other CPUs can also have this problem.
+			return 0;
+		}
+#endif
+
 		constexpr ullong timer_freq = 1'000'000'000;
 #endif
 


### PR DESCRIPTION
This PR is about re-enabling a performance feature (TSC) for Ryzen CPUs in RPCS3, which was previously disabled — but doing it safely and only when it's actually supported by the OS.

The Problem - Some Ryzen laptops running Linux had bad firmware or kernel settings that made the TSC unreliable. As a result, RPCS3 would freeze, stutter, or behave incorrectly when using TSC on these systems.  So TSC was disabled entirely for all Ryzen CPUs as a safety measure. But that hurt performance — by as much as 15% in games like Red Dead Redemption.

The PR restores TSC usage but in a conditional way:

On Windows:
Just enable TSC again for Ryzen CPUs. Because Windows firmware usually handles TSC better, and there are no major issues reported.

On Linux:
Check if the Linux kernel itself trusts the TSC:
Read the file: /sys/devices/system/clocksource/clocksource0/available_clocksource
If tsc is listed there → the kernel says it's reliable → enable it.
If not → disable TSC.

On macOS/BSD:
No change. Still disables TSC for Ryzen by default — because behavior is unknown or M-series ARM-based chip.

FIXES - 
#16643: Ryzen laptops had TSC disabled globally — now it’s restored conditionally.
#16604: Fixed the 15% performance regression in Red Dead Redemption.
#16545: General Ryzen and TSC bug tracking.

