### PR TITLE
1550 ppu memory write breakpoints

### DIFF
--- a/rpcs3/Emu/Cell/PPUThread.cpp
+++ b/rpcs3/Emu/Cell/PPUThread.cpp
@@ -2462,11 +2462,6 @@ void ppu_thread::serialize_common(utils::serial& ar)
 		fmt::throw_exception("Failed to serialize PPU thread ID=0x%x (cia=0x%x, ar=%s)", this->id, cia, ar);
 	}
 
-	if (ar.is_writing())
-	{
-		ppu_log.notice("Saving PPU Thread [0x%x: %s]: cia=0x%x, state=%s", id, *ppu_tname.load(), cia, +state);
-	}
-
 	ar(optional_savestate_state, vr);
 
 	if (!ar.is_writing())
@@ -2538,7 +2533,10 @@ ppu_thread::ppu_thread(utils::serial& ar)
 		}
 	};
 
-	switch (const u32 status = ar.pop<u32>())
+	
+	const u32 status = ar.pop<u32>();
+
+	switch (status)
 	{
 	case PPU_THREAD_STATUS_IDLE:
 	{
@@ -2669,12 +2667,14 @@ ppu_thread::ppu_thread(utils::serial& ar)
 
 	ppu_tname = make_single<std::string>(ar.pop<std::string>());
 
-	ppu_log.notice("Loading PPU Thread [0x%x: %s]: cia=0x%x, state=%s", id, *ppu_tname.load(), cia, +state);
+	ppu_log.notice("Loading PPU Thread [0x%x: %s]: cia=0x%x, state=%s, status=%s", id, *ppu_tname.load(), cia, +stateppu_thread_status{status});
 }
 
 void ppu_thread::save(utils::serial& ar)
 {
 
+	// For debugging purposes, load this as soon as this function enters
+	const bs_t<cpu_flag> state_flags = state;
 
 	USING_SERIALIZATION_VERSION(ppu);
 
@@ -2725,6 +2725,15 @@ void ppu_thread::save(utils::serial& ar)
 	}
 
 	ar(*ppu_tname.load());
+
+	if (current_module && current_module[0])
+	{
+		ppu_log.notice("Saving PPU Thread [0x%x: %s]: cia=0x%x, state=%s, statu=%s (at function: %s)", id, *ppu_tname.load(), cia, state_flags, ppu_thread_status{status}, last_function);
+	}
+	else
+	{
+		ppu_log.notice("Saving PPU Thread [0x%x: %s]: cia=0x%x, state=%s, statu=%s", id, *ppu_tname.load(), cia, state_flags, ppu_thread_status{status});
+	}
 
 
 }

--- a/rpcs3/Emu/RSX/RSXThread.cpp
+++ b/rpcs3/Emu/RSX/RSXThread.cpp
@@ -953,7 +953,7 @@ namespace rsx
 		}
 
 		// Wait for startup (TODO)
-		while (!rsx_thread_running || Emu.IsPaused())
+		while (!rsx_thread_running || Emu.IsPausedOrReady())
 		{
 			// Execute backend-local tasks first
 			do_local_task(performance_counters.state);

--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -3006,6 +3006,11 @@ void Emulator::Kill(bool allow_autoexit, bool savestate, savestate_stage* save_s
 	if (!IsStopped() && savestate)
 	{
 
+		if (IsStarting())
+		{
+			return;
+		}
+
 		if (!save_stage || !save_stage->prepared)
 		{
 			if (m_emu_state_close_pending.exchange(true))

--- a/rpcs3/util/sysinfo.cpp
+++ b/rpcs3/util/sysinfo.cpp
@@ -23,7 +23,7 @@
 #endif
 
 #include <thread>
-
+#include <fstream>
 #include "util/asm.hpp"
 #include "util/fence.hpp"
 
@@ -822,6 +822,50 @@ static const bool s_tsc_freq_evaluated = []() -> bool
 
 		const ullong timer_freq = freq.QuadPart;
 #else
+
+#ifdef __linux__
+		// Check if system clocksource is TSC. If the kernel trusts the TSC, we should too.
+		// Some Ryzen laptops have broken firmware when running linux (requires a kernel patch). This is also a problem on some older intel CPUs.
+		const char* clocksource_file = "/sys/devices/system/clocksource/clocksource0/available_clocksource";
+		if (!fs::is_file(clocksource_file))
+		{
+			// OS doesn't support sysfs?
+			printf("[TSC calibration] Could not determine available clock sources. Disabling TSC.\n");
+			return 0;
+		}
+
+		std::string clock_sources;
+		std::ifstream file(clocksource_file);
+		std::getline(file, clock_sources);
+
+		if (file.fail())
+		{
+			printf("[TSC calibration] Could not read the available clock sources on this system. Disabling TSC.\n");
+			return 0;
+		}
+
+		printf("[TSC calibration] Available clock sources: '%s'\n", clock_sources.c_str());
+
+		// Check if the Kernel has blacklisted the TSC
+		const auto available_clocks = fmt::split(clock_sources, { " " });
+		const bool tsc_reliable = std::find(available_clocks.begin(), available_clocks.end(), "tsc") != available_clocks.end();
+
+		if (!tsc_reliable)
+		{
+			printf("[TSC calibration] TSC is not a supported clock source on this system.\n");
+			return 0;
+		}
+
+		printf("[TSC calibration] Kernel reports the TSC is reliable.\n");
+#else
+		if (utils::get_cpu_brand().find("Ryzen") != umax)
+		{
+			// MacOS is arm-native these days and I don't know much about BSD to fix this if it's an issue. (kd-11)
+			// Having this check only for Ryzen is broken behavior - other CPUs can also have this problem.
+			return 0;
+		}
+#endif
+
 		constexpr ullong timer_freq = 1'000'000'000;
 #endif
 


### PR DESCRIPTION
RPCS3 already had support for write breakpoints, but they didn’t work for some PPU instructions — like STVX, STFS, STFDX, etc. Because those instructions wrote directly using vm::_ref<type> instead of the macro wrappers like PPU_WRITE_*.
The macro wrappers are what actually trigger the breakpoint system. So, the instructions were writing to memory, but the emulator didn’t notice → no breakpoint triggered.

Thus, replaced direct writes like vm::_ref<f64>(addr) = value; with PPU_WRITE(f64, addr, value);

PPU_WRITE(f64, addr, value) calls a special vm::write(...) function that: Writes the value. Checks if a write breakpoint is set at that address. If yes → logs it and pauses the emulator.


Breakpoints now trigger correctly for all memory-writing instructions.
Helps developers and testers debug tricky game bugs.
Future support for advanced debugging (e.g., cheat engines, memory scanners) is now more robust.
